### PR TITLE
update sqlitecpp sources to use latest version from git

### DIFF
--- a/example/addons.make
+++ b/example/addons.make
@@ -1,1 +1,2 @@
+ofxJSON
 ofxSQLiteCpp

--- a/libs/SQLiteCpp/include/SQLiteCpp/Database.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/Database.h
@@ -336,6 +336,25 @@ public:
                               apApp, apFunc, apStep, apFinal, apDestroy);
     }
 
+
+    /**
+     * @brief Load a module into the current sqlite database instance. 
+     *
+     *  This is the equivalent of the sqlite3_load_extension call, but additionally enables
+     *  module loading support prior to loading the requested module.
+     *
+     * @see http://www.sqlite.org/c3ref/load_extension.html
+     *
+     * @note UTF-8 text encoding assumed.
+     *
+     * @param[in] apExtensionName   Name of the shared library containing extension
+     * @param[in] apEntryPointName  Name of the entry point (NULL to let sqlite work it out)
+     *
+     * @throw SQLite::Exception in case of error
+     */
+    void loadExtension(const char* apExtensionName,
+         const char *apEntryPointName);
+
 private:
     /// @{ Database must be non-copyable
     Database(const Database&);

--- a/libs/SQLiteCpp/include/SQLiteCpp/Exception.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/Exception.h
@@ -45,10 +45,14 @@ public:
 #endif
 
 // Detect whether the compiler supports C++11 noexcept exception specifications.
-#if (defined(__GNUC__) && (__GNUC__ >= 4 && __GNUC_MINOR__ >= 7 ) && defined(__GXX_EXPERIMENTAL_CXX0X__))
+#if (  defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || (__GNUC__ > 4)) \
+    && defined(__GXX_EXPERIMENTAL_CXX0X__))
 // GCC 4.7 and following have noexcept
 #elif defined(__clang__) && __has_feature(cxx_noexcept)
 // Clang 3.0 and above have noexcept
+#elif defined(_MSC_VER) && _MSC_VER > 1800
+// Visual Studio 2015 and above have noexcept
 #else
-    #define noexcept    throw()
+    // Visual Studio 2013 does not support noexcept, and "throw()" is deprecated by C++11
+    #define noexcept
 #endif

--- a/libs/SQLiteCpp/include/SQLiteCpp/SQLiteCpp.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/SQLiteCpp.h
@@ -38,5 +38,5 @@
  * with the value (X*1000000 + Y*1000 + Z) where X, Y, and Z are the same
  * numbers used in [SQLITECPP_VERSION].
  */
-#define SQLITECPP_VERSION           "1.0.0"
-#define SQLITECPP_VERSION_NUMBER    1000000
+#define SQLITECPP_VERSION           "1.1.0"
+#define SQLITECPP_VERSION_NUMBER    1001000

--- a/libs/SQLiteCpp/include/SQLiteCpp/Statement.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/Statement.h
@@ -44,9 +44,9 @@ class Column;
  */
 class Statement
 {
-public:
-    class Ptr;
+    friend class Column; // For access to Statement::Ptr inner class
 
+public:
     /**
      * @brief Compile and register the SQL query for the provided SQLite Database Connection
      *
@@ -400,7 +400,7 @@ public:
         return sqlite3_errmsg(mStmtPtr);
     }
 
-public:
+private:
     /**
      * @brief Shared pointer to the sqlite3_stmt SQLite Statement Object.
      *

--- a/libs/SQLiteCpp/src/Column.cpp
+++ b/libs/SQLiteCpp/src/Column.cpp
@@ -65,7 +65,7 @@ double Column::getDouble() const noexcept // nothrow
 // Return a pointer to the text value (NULL terminated string) of the column specified by its index starting at 0
 const char* Column::getText(const char* apDefaultValue /* = "" */) const noexcept // nothrow
 {
-    const char* pText = (const char*)sqlite3_column_text(mStmtPtr, mIndex);
+    const char* pText = reinterpret_cast<const char*>(sqlite3_column_text(mStmtPtr, mIndex));
     return (pText?pText:apDefaultValue);
 }
 

--- a/vs2015/sqlitecpp.props
+++ b/vs2015/sqlitecpp.props
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;SQLITE_ENABLE_COLUMN_METADATA;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>


### PR DESCRIPTION
...so that it would compile properly on VS2015 / oF 0.9.0 Windows.

Also note that to compile sqlite.c in VS2015 the file
has to be selected, and in the file's options under
C/C++ -> Advanced -> Compile As : Compile as C Code /TC
needs to be selected. This for both the debug and the
Release Configuration.

Note further that the .props file holds some of the
preprocessor settings that SQLiteCpp suggests using
for Visual Studio, but these appear to be optional.

that's github repo https://github.com/SRombauts/SQLiteCpp.git
at hash: af78d59349fd013341746b345961e3f19ecae60d
